### PR TITLE
Fix Str::mb_ucwords()

### DIFF
--- a/src/helpers/class-str.php
+++ b/src/helpers/class-str.php
@@ -229,6 +229,12 @@ class Str {
 			return ucwords( $string );
 		}
 
-		return mb_convert_case( $string, MB_CASE_TITLE, 'UTF-8' );
+		$words = preg_split( '/([\s]+)/u', $string, -1, PREG_SPLIT_DELIM_CAPTURE );
+		$ucwords = '';
+		foreach ( $words as $word ) {
+			$ucwords .= preg_match( '/[\p{L}]/u', $word[0] ) ? mb_strtoupper( $word[0], 'UTF-8' ) . mb_substr( $word, 1, mb_strlen( $word ), 'UTF-8' ) : $word;
+		}
+
+		return $ucwords;
 	}
 }


### PR DESCRIPTION
Change behavior to be more like `ucwords()`: turn the first character of each word to uppercase, but **do not turn the rest of the characters to lowercase**.